### PR TITLE
feat: add keep-snapshots option to serve-snapshots

### DIFF
--- a/cmd/ksync/commands/root.go
+++ b/cmd/ksync/commands/root.go
@@ -21,6 +21,7 @@ var (
 	metricsPort       int64
 	snapshotPort      int64
 	pruning           bool
+	keepSnapshots     bool
 	backupInterval    int64
 	backupKeepRecent  int64
 	backupCompression string

--- a/cmd/ksync/commands/serve.go
+++ b/cmd/ksync/commands/serve.go
@@ -44,7 +44,8 @@ func init() {
 
 	serveCmd.Flags().Int64Var(&startHeight, "start-height", 0, "start creating snapshots at this height. note that pruning should be false when using start height")
 
-	serveCmd.Flags().BoolVar(&pruning, "pruning", true, "prune application, state and blockstore db")
+	serveCmd.Flags().BoolVar(&pruning, "pruning", true, "prune application.db, state.db, blockstore db and snapshots")
+	serveCmd.Flags().BoolVar(&keepSnapshots, "keep-snapshots", false, "keep snapshots, although pruning might be enabled")
 
 	rootCmd.AddCommand(serveCmd)
 }
@@ -78,7 +79,7 @@ var serveCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		servesnapshots.StartServeSnapshotsWithBinary(consensusEngine, binaryPath, homePath, chainRest, storageRest, blockPoolId, metrics, metricsPort, snapshotPoolId, snapshotPort, startHeight, pruning)
+		servesnapshots.StartServeSnapshotsWithBinary(consensusEngine, binaryPath, homePath, chainRest, storageRest, blockPoolId, metrics, metricsPort, snapshotPoolId, snapshotPort, startHeight, pruning, keepSnapshots)
 
 		if err := consensusEngine.CloseDBs(); err != nil {
 			logger.Error().Msg(fmt.Sprintf("failed to close dbs in engine: %s", err))

--- a/servesnapshots/servesnapshots.go
+++ b/servesnapshots/servesnapshots.go
@@ -20,7 +20,7 @@ var (
 	logger = utils.KsyncLogger("serve-snapshots")
 )
 
-func StartServeSnapshotsWithBinary(engine types.Engine, binaryPath, homePath, chainRest, storageRest string, blockPoolId int64, metricsServer bool, metricsPort, snapshotPoolId, snapshotPort, startHeight int64, pruning bool) {
+func StartServeSnapshotsWithBinary(engine types.Engine, binaryPath, homePath, chainRest, storageRest string, blockPoolId int64, metricsServer bool, metricsPort, snapshotPoolId, snapshotPort, startHeight int64, pruning, keepSnapshots bool) {
 	logger.Info().Msg("starting serve-snapshots")
 
 	// get snapshot interval from pool
@@ -42,11 +42,23 @@ func StartServeSnapshotsWithBinary(engine types.Engine, binaryPath, homePath, ch
 	if pruning {
 		snapshotArgs = append(
 			snapshotArgs,
-			"--state-sync.snapshot-keep-recent",
-			strconv.FormatInt(utils.SnapshotPruningWindowFactor, 10),
 			"--pruning-keep-recent",
 			strconv.FormatInt(utils.SnapshotPruningWindowFactor*config.Interval, 10),
 		)
+
+		if keepSnapshots {
+			snapshotArgs = append(
+				snapshotArgs,
+				"--state-sync.snapshot-keep-recent",
+				"0",
+			)
+		} else {
+			snapshotArgs = append(
+				snapshotArgs,
+				"--state-sync.snapshot-keep-recent",
+				strconv.FormatInt(utils.SnapshotPruningWindowFactor, 10),
+			)
+		}
 	} else {
 		snapshotArgs = append(
 			snapshotArgs,


### PR DESCRIPTION
For protocol node runners it was important to "reuse" the KSYNC process for testnet and mainnet, therefore normal pruning should still take place, but snapshots should be kept for that reason.