### PR TITLE
fix: stop proxy app and prevent error log

### DIFF
--- a/blocksync/executor.go
+++ b/blocksync/executor.go
@@ -22,7 +22,11 @@ func StartDBExecutor(engine types.Engine, chainRest, storageRest string, blockPo
 	if err != nil {
 		return fmt.Errorf("failed to get continuation height from engine: %w", err)
 	}
-	
+
+	if err := engine.StartProxyApp(); err != nil {
+		return fmt.Errorf("failed to start proxy app: %w", err)
+	}
+
 	if err := engine.DoHandshake(); err != nil {
 		return fmt.Errorf("failed to do handshake: %w", err)
 	}
@@ -179,6 +183,10 @@ func StartDBExecutor(engine types.Engine, chainRest, storageRest string, blockPo
 
 			// stop with block execution if we have reached our target height
 			if targetHeight > 0 && height == targetHeight+1 {
+				if err := engine.StopProxyApp(); err != nil {
+					return fmt.Errorf("failed to stop proxy app: %w", err)
+				}
+
 				logger.Info().Msg(fmt.Sprintf("block-synced from %d to height %d", continuationHeight, targetHeight))
 				return nil
 			}

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -15,8 +15,14 @@ type Engine interface {
 	// GetHomePath gets the home path of the config and data folder
 	GetHomePath() string
 
-	// GetProxyApp gets the proxy app address of the TSP connection
-	GetProxyApp() string
+	// GetProxyAppAddress gets the proxy app address of the TSP connection
+	GetProxyAppAddress() string
+
+	// StartProxyApp starts the proxy app connections to the app
+	StartProxyApp() error
+
+	// StopProxyApp stops the proxy app connections to the app
+	StopProxyApp() error
 
 	// GetChainId gets the chain id of the app
 	GetChainId() (string, error)

--- a/utils/binaries.go
+++ b/utils/binaries.go
@@ -60,7 +60,7 @@ func StartBinaryProcessForDB(engine types.Engine, binaryPath string, debug bool,
 		engine.GetHomePath(),
 		"--with-tendermint=false",
 		"--address",
-		engine.GetProxyApp(),
+		engine.GetProxyAppAddress(),
 	}, args...)
 
 	cmd := exec.Command(cmdPath, append(startArgs, baseArgs...)...)


### PR DESCRIPTION
Fix the following error log:

`12:50PM ERR [APP] Stopping abci.socketClient for error: read message: EOF
12:50PM INF [APP] Stopping socketClient service impl=socketClient
12:50PM ERR [APP] Stopping abci.socketClient for error: read message: EOF
12:50PM INF [APP] Stopping socketClient service impl=socketClient`

by stopping the proxy app connection before the chain binary gets terminated. For that new methods have been added to the engine interface