### PR TITLE
fix: make --home flag optional in state-sync command

### DIFF
--- a/cmd/ksync/commands/statesync.go
+++ b/cmd/ksync/commands/statesync.go
@@ -20,9 +20,6 @@ func init() {
 	}
 
 	stateSyncCmd.Flags().StringVar(&homePath, "home", "", "home directory")
-	if err := stateSyncCmd.MarkFlagRequired("home"); err != nil {
-		panic(fmt.Errorf("flag 'home' should be required: %w", err))
-	}
 
 	stateSyncCmd.Flags().StringVar(&chainId, "chain-id", utils.DefaultChainId, fmt.Sprintf("KYVE chain id [\"%s\",\"%s\",\"%s\"]", utils.ChainIdMainnet, utils.ChainIdKaon, utils.ChainIdKorellia))
 


### PR DESCRIPTION
The --home flag has optional since v1.1.0, but for state-sync it was still required. This has been fixed to be optional from now on