### PR TITLE
chore: added --x-crisis-skip-assert-invariants flag

### DIFF
--- a/blocksync/blocksync.go
+++ b/blocksync/blocksync.go
@@ -77,7 +77,7 @@ func PerformBlockSyncValidationChecks(engine types.Engine, chainRest string, blo
 	return nil
 }
 
-func StartBlockSyncWithBinary(engine types.Engine, binaryPath, homePath, chainId, chainRest, storageRest string, blockPoolId, targetHeight int64, metrics bool, port int64, backupCfg *types.BackupConfig, optOut, debug, userInput bool) {
+func StartBlockSyncWithBinary(engine types.Engine, binaryPath, homePath, chainId, chainRest, storageRest string, blockPoolId, targetHeight int64, metrics bool, port int64, backupCfg *types.BackupConfig, skipCrisisInvariants, optOut, debug, userInput bool) {
 	logger.Info().Msg("starting block-sync")
 
 	utils.TrackSyncStartEvent(engine, utils.BLOCK_SYNC, chainId, chainRest, storageRest, targetHeight, optOut)
@@ -88,9 +88,14 @@ func StartBlockSyncWithBinary(engine types.Engine, binaryPath, homePath, chainId
 		os.Exit(1)
 	}
 
-	if err := bootstrap.StartBootstrapWithBinary(engine, binaryPath, homePath, chainRest, storageRest, blockPoolId, debug); err != nil {
+	if err := bootstrap.StartBootstrapWithBinary(engine, binaryPath, homePath, chainRest, storageRest, blockPoolId, skipCrisisInvariants, debug); err != nil {
 		logger.Error().Msg(fmt.Sprintf("failed to bootstrap node: %s", err))
 		os.Exit(1)
+	}
+
+	args := make([]string, 0)
+	if skipCrisisInvariants {
+		args = append(args, "--x-crisis-skip-assert-invariants")
 	}
 
 	// start binary process thread

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -14,7 +14,7 @@ var (
 	logger = utils.KsyncLogger("bootstrap")
 )
 
-func StartBootstrapWithBinary(engine types.Engine, binaryPath, homePath, chainRest, storageRest string, poolId int64, debug bool) error {
+func StartBootstrapWithBinary(engine types.Engine, binaryPath, homePath, chainRest, storageRest string, poolId int64, skipCrisisInvariants, debug bool) error {
 	logger.Info().Msg("starting bootstrap")
 
 	gt100, err := utils.IsFileGreaterThanOrEqualTo100MB(engine.GetGenesisPath())
@@ -67,8 +67,13 @@ func StartBootstrapWithBinary(engine types.Engine, binaryPath, homePath, chainRe
 		return fmt.Errorf("failed to close dbs in engine: %w", err)
 	}
 
+	args := make([]string, 0)
+	if skipCrisisInvariants {
+		args = append(args, "--x-crisis-skip-assert-invariants")
+	}
+
 	// start binary process thread
-	processId, err := utils.StartBinaryProcessForP2P(engine, binaryPath, debug, []string{})
+	processId, err := utils.StartBinaryProcessForP2P(engine, binaryPath, debug, args)
 	if err != nil {
 		return err
 	}

--- a/cmd/ksync/commands/blocksync.go
+++ b/cmd/ksync/commands/blocksync.go
@@ -42,6 +42,8 @@ func init() {
 	blockSyncCmd.Flags().StringVar(&backupCompression, "backup-compression", "", "compression type used for backups (\"tar.gz\",\"zip\")")
 	blockSyncCmd.Flags().StringVar(&backupDest, "backup-dest", "", fmt.Sprintf("path where backups should be stored (default = %s)", utils.DefaultBackupPath))
 
+	blockSyncCmd.Flags().BoolVar(&skipCrisisInvariants, "x-crisis-skip-assert-invariants", false, "skip x/crisis invariants check on startup")
+
 	blockSyncCmd.Flags().BoolVarP(&reset, "reset-all", "r", false, "reset this node's validator to genesis state")
 	blockSyncCmd.Flags().BoolVar(&optOut, "opt-out", false, "disable the collection of anonymous usage data")
 	blockSyncCmd.Flags().BoolVarP(&debug, "debug", "d", false, "show logs from tendermint app")
@@ -88,7 +90,7 @@ var blockSyncCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		blocksync.StartBlockSyncWithBinary(consensusEngine, binaryPath, homePath, chainId, chainRest, storageRest, bId, targetHeight, metrics, metricsPort, backupCfg, optOut, debug, !y)
+		blocksync.StartBlockSyncWithBinary(consensusEngine, binaryPath, homePath, chainId, chainRest, storageRest, bId, targetHeight, metrics, metricsPort, backupCfg, skipCrisisInvariants, optOut, debug, !y)
 
 		if err := consensusEngine.CloseDBs(); err != nil {
 			logger.Error().Msg(fmt.Sprintf("failed to close dbs in engine: %s", err))

--- a/cmd/ksync/commands/root.go
+++ b/cmd/ksync/commands/root.go
@@ -7,31 +7,32 @@ import (
 )
 
 var (
-	engine            string
-	binaryPath        string
-	homePath          string
-	chainId           string
-	chainRest         string
-	storageRest       string
-	snapshotPoolId    string
-	blockPoolId       string
-	startHeight       int64
-	targetHeight      int64
-	metrics           bool
-	metricsPort       int64
-	snapshotPort      int64
-	source            string
-	pruning           bool
-	keepSnapshots     bool
-	backupInterval    int64
-	backupKeepRecent  int64
-	backupCompression string
-	backupDest        string
-	reset             bool
-	keepAddrBook      bool
-	optOut            bool
-	debug             bool
-	y                 bool
+	engine               string
+	binaryPath           string
+	homePath             string
+	chainId              string
+	chainRest            string
+	storageRest          string
+	snapshotPoolId       string
+	blockPoolId          string
+	startHeight          int64
+	targetHeight         int64
+	metrics              bool
+	metricsPort          int64
+	snapshotPort         int64
+	source               string
+	pruning              bool
+	keepSnapshots        bool
+	backupInterval       int64
+	backupKeepRecent     int64
+	backupCompression    string
+	backupDest           string
+	skipCrisisInvariants bool
+	reset                bool
+	keepAddrBook         bool
+	optOut               bool
+	debug                bool
+	y                    bool
 )
 
 var (

--- a/cmd/ksync/commands/serve.go
+++ b/cmd/ksync/commands/serve.go
@@ -42,6 +42,8 @@ func init() {
 	serveCmd.Flags().BoolVar(&pruning, "pruning", true, "prune application.db, state.db, blockstore db and snapshots")
 	serveCmd.Flags().BoolVar(&keepSnapshots, "keep-snapshots", false, "keep snapshots, although pruning might be enabled")
 
+	serveCmd.Flags().BoolVar(&skipCrisisInvariants, "x-crisis-skip-assert-invariants", false, "skip x/crisis invariants check on startup")
+
 	serveCmd.Flags().BoolVarP(&reset, "reset-all", "r", false, "reset this node's validator to genesis state")
 	serveCmd.Flags().BoolVar(&optOut, "opt-out", false, "disable the collection of anonymous usage data")
 	serveCmd.Flags().BoolVarP(&debug, "debug", "d", false, "show logs from tendermint app")
@@ -82,7 +84,7 @@ var serveCmd = &cobra.Command{
 		}
 
 		utils.TrackServeSnapshotsEvent(consensusEngine, chainId, chainRest, storageRest, snapshotPort, metrics, metricsPort, startHeight, pruning, keepSnapshots, debug, optOut)
-		servesnapshots.StartServeSnapshotsWithBinary(consensusEngine, binaryPath, homePath, chainRest, storageRest, bId, metrics, metricsPort, sId, snapshotPort, startHeight, pruning, keepSnapshots, debug)
+		servesnapshots.StartServeSnapshotsWithBinary(consensusEngine, binaryPath, homePath, chainRest, storageRest, bId, metrics, metricsPort, sId, snapshotPort, startHeight, skipCrisisInvariants, pruning, keepSnapshots, debug)
 
 		if err := consensusEngine.CloseDBs(); err != nil {
 			logger.Error().Msg(fmt.Sprintf("failed to close dbs in engine: %s", err))

--- a/heightsync/heightsync.go
+++ b/heightsync/heightsync.go
@@ -115,7 +115,7 @@ func StartHeightSyncWithBinary(engine types.Engine, binaryPath, homePath, chainI
 		}
 	} else {
 		// if we have to sync from genesis we first bootstrap the node
-		if err := bootstrap.StartBootstrapWithBinary(engine, binaryPath, homePath, chainRest, storageRest, blockPoolId, debug); err != nil {
+		if err := bootstrap.StartBootstrapWithBinary(engine, binaryPath, homePath, chainRest, storageRest, blockPoolId, false, debug); err != nil {
 			logger.Error().Msg(fmt.Sprintf("failed to bootstrap node: %s", err))
 			os.Exit(1)
 		}

--- a/servesnapshots/servesnapshots.go
+++ b/servesnapshots/servesnapshots.go
@@ -20,7 +20,7 @@ var (
 	logger = utils.KsyncLogger("serve-snapshots")
 )
 
-func StartServeSnapshotsWithBinary(engine types.Engine, binaryPath, homePath, chainRest, storageRest string, blockPoolId int64, metricsServer bool, metricsPort, snapshotPoolId, snapshotPort, startHeight int64, pruning, keepSnapshots, debug bool) {
+func StartServeSnapshotsWithBinary(engine types.Engine, binaryPath, homePath, chainRest, storageRest string, blockPoolId int64, metricsServer bool, metricsPort, snapshotPoolId, snapshotPort, startHeight int64, skipCrisisInvariants, pruning, keepSnapshots, debug bool) {
 	logger.Info().Msg("starting serve-snapshots")
 
 	// get snapshot interval from pool
@@ -154,7 +154,7 @@ func StartServeSnapshotsWithBinary(engine types.Engine, binaryPath, homePath, ch
 		}
 	} else {
 		// if we have to sync from genesis we first bootstrap the node
-		if err := bootstrap.StartBootstrapWithBinary(engine, binaryPath, homePath, chainRest, storageRest, blockPoolId, debug); err != nil {
+		if err := bootstrap.StartBootstrapWithBinary(engine, binaryPath, homePath, chainRest, storageRest, blockPoolId, skipCrisisInvariants, debug); err != nil {
 			logger.Error().Msg(fmt.Sprintf("failed to bootstrap node: %s", err))
 			os.Exit(1)
 		}


### PR DESCRIPTION
added --x-crisis-skip-assert-invariants flag for `serve-snapshots` and `block-sync` commands