### PR TITLE
fix: do not exit when end height does not exist yet

### DIFF
--- a/blocksync/blocksync.go
+++ b/blocksync/blocksync.go
@@ -20,7 +20,7 @@ func StartBlockSync(engine types.Engine, chainRest, storageRest string, poolId, 
 	return StartDBExecutor(engine, chainRest, storageRest, poolId, targetHeight, metrics, port, 0, 0, utils.DefaultSnapshotServerPort, false, false, backupCfg)
 }
 
-func PerformBlockSyncValidationChecks(engine types.Engine, chainRest string, blockPoolId, targetHeight int64, userInput bool) error {
+func PerformBlockSyncValidationChecks(engine types.Engine, chainRest string, blockPoolId, targetHeight int64, checkEndHeight, userInput bool) error {
 	continuationHeight, err := engine.GetContinuationHeight()
 	if err != nil {
 		return fmt.Errorf("failed to get continuation height from engine: %w", err)
@@ -48,7 +48,7 @@ func PerformBlockSyncValidationChecks(engine types.Engine, chainRest string, blo
 		return fmt.Errorf("requested target height is %d but app is already at block height %d", targetHeight, continuationHeight)
 	}
 
-	if targetHeight > 0 && targetHeight > endHeight {
+	if checkEndHeight && targetHeight > 0 && targetHeight > endHeight {
 		return fmt.Errorf("requested target height is %d but last available block on pool is %d", targetHeight, endHeight)
 	}
 
@@ -83,7 +83,7 @@ func StartBlockSyncWithBinary(engine types.Engine, binaryPath, homePath, chainId
 	utils.TrackSyncStartEvent(engine, utils.BLOCK_SYNC, chainId, chainRest, storageRest, targetHeight, optOut)
 
 	// perform validation checks before booting state-sync process
-	if err := PerformBlockSyncValidationChecks(engine, chainRest, blockPoolId, targetHeight, userInput); err != nil {
+	if err := PerformBlockSyncValidationChecks(engine, chainRest, blockPoolId, targetHeight, true, userInput); err != nil {
 		logger.Error().Msg(fmt.Sprintf("block-sync validation checks failed: %s", err))
 		os.Exit(1)
 	}

--- a/heightsync/heightsync.go
+++ b/heightsync/heightsync.go
@@ -42,7 +42,7 @@ func StartHeightSyncWithBinary(engine types.Engine, binaryPath, homePath, chainI
 		logger.Info().Msg(fmt.Sprintf("target height not specified, searching for latest available block height"))
 	}
 
-	if err := blocksync.PerformBlockSyncValidationChecks(engine, chainRest, blockPoolId, targetHeight, false); err != nil {
+	if err := blocksync.PerformBlockSyncValidationChecks(engine, chainRest, blockPoolId, targetHeight, true, false); err != nil {
 		logger.Error().Msg(fmt.Sprintf("block-sync validation checks failed: %s", err))
 		os.Exit(1)
 	}

--- a/servesnapshots/servesnapshots.go
+++ b/servesnapshots/servesnapshots.go
@@ -100,7 +100,7 @@ func StartServeSnapshotsWithBinary(engine types.Engine, binaryPath, homePath, ch
 		}
 	}
 
-	if err := blocksync.PerformBlockSyncValidationChecks(engine, chainRest, blockPoolId, targetHeight, false); err != nil {
+	if err := blocksync.PerformBlockSyncValidationChecks(engine, chainRest, blockPoolId, targetHeight, false, false); err != nil {
 		logger.Error().Msg(fmt.Sprintf("block-sync validation checks failed: %s", err))
 		os.Exit(1)
 	}


### PR DESCRIPTION
When specifying the target-height on serve-snapshots ksync should not exit if the target height does not exist on the pool yet, instead it should only exit once the target height is reached.