### PR TITLE
chore: use latest complete snapshot

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -26,11 +26,12 @@ type PoolResponse = struct {
 	Pool struct {
 		Id   int64 `json:"id"`
 		Data struct {
-			Runtime      string `json:"runtime"`
-			StartKey     string `json:"start_key"`
-			CurrentKey   string `json:"current_key"`
-			TotalBundles int64  `json:"total_bundles"`
-			Config       string `json:"config"`
+			Runtime        string `json:"runtime"`
+			StartKey       string `json:"start_key"`
+			CurrentKey     string `json:"current_key"`
+			CurrentSummary string `json:"current_summary"`
+			TotalBundles   int64  `json:"total_bundles"`
+			Config         string `json:"config"`
 		} `json:"data"`
 	} `json:"pool"`
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -123,7 +123,7 @@ func GetFromUrlWithOptions(url string, options GetFromUrlOptions) ([]byte, error
 
 // GetFromUrlWithBackoff tries to fetch data from url with exponential backoff
 func GetFromUrlWithBackoff(url string) (data []byte, err error) {
-	return GetFromUrlWithOptions(url, GetFromUrlOptions{SkipTLSVerification: true})
+	return GetFromUrlWithOptions(url, GetFromUrlOptions{SkipTLSVerification: true, WithBackoff: true})
 }
 
 func CreateSha256Checksum(input []byte) (hash string) {


### PR DESCRIPTION
KSYNC now checks if the current snapshot being archived by a state-sync pool is a complete snapshot, if yes it is used instead of using the snapshot before. This enables users to state-sync to the actual latest available snapshot height