### PR TITLE
fix: locked database

### DIFF
--- a/blocksync/blocksync.go
+++ b/blocksync/blocksync.go
@@ -77,7 +77,7 @@ func PerformBlockSyncValidationChecks(engine types.Engine, chainRest string, blo
 	return
 }
 
-func StartBlockSyncWithBinary(engine types.Engine, binaryPath, homePath, chainId, chainRest, storageRest string, blockRpcConfig *types.BlockRpcConfig, blockPoolId *int64, targetHeight int64, backupCfg *types.BackupConfig, appFlags string, optOut, debug bool) {
+func StartBlockSyncWithBinary(engine types.Engine, binaryPath, homePath, chainId, chainRest, storageRest string, blockRpcConfig *types.BlockRpcConfig, blockPoolId *int64, targetHeight int64, backupCfg *types.BackupConfig, appFlags string, rpcServer, optOut, debug bool) {
 	logger.Info().Msg("starting block-sync")
 
 	if err := bootstrap.StartBootstrapWithBinary(engine, binaryPath, homePath, chainRest, storageRest, blockRpcConfig, blockPoolId, appFlags, debug); err != nil {
@@ -91,9 +91,13 @@ func StartBlockSyncWithBinary(engine types.Engine, binaryPath, homePath, chainId
 		panic(err)
 	}
 
-	if err := engine.OpenDBs(homePath); err != nil {
+	if err := engine.OpenDBs(); err != nil {
 		logger.Error().Msg(fmt.Sprintf("failed to open dbs in engine: %s", err))
 		os.Exit(1)
+	}
+
+	if rpcServer {
+		go engine.StartRPCServer()
 	}
 
 	utils.TrackSyncStartEvent(engine, utils.BLOCK_SYNC, chainId, chainRest, storageRest, targetHeight, optOut)

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -18,6 +18,13 @@ var (
 func StartBootstrapWithBinary(engine types.Engine, binaryPath, homePath, chainRest, storageRest string, blockRpcConfig *types.BlockRpcConfig, poolId *int64, appFlags string, debug bool) error {
 	logger.Info().Msg("starting bootstrap")
 
+	if err := engine.OpenDBs(homePath); err != nil {
+		return fmt.Errorf("failed to open dbs in engine: %w", err)
+	}
+
+	// TODO: handle error
+	defer engine.CloseDBs()
+
 	gt100, err := utils.IsFileGreaterThanOrEqualTo100MB(engine.GetGenesisPath())
 	if err != nil {
 		return err
@@ -123,10 +130,6 @@ func StartBootstrapWithBinary(engine types.Engine, binaryPath, homePath, chainRe
 
 	// wait until process has properly shut down
 	time.Sleep(10 * time.Second)
-
-	if err := engine.OpenDBs(homePath); err != nil {
-		return fmt.Errorf("failed to open dbs in engine: %w", err)
-	}
 
 	logger.Info().Msg("successfully bootstrapped node. Continuing with syncing blocks over DB")
 	return nil

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -18,12 +18,14 @@ var (
 func StartBootstrapWithBinary(engine types.Engine, binaryPath, homePath, chainRest, storageRest string, blockRpcConfig *types.BlockRpcConfig, poolId *int64, appFlags string, debug bool) error {
 	logger.Info().Msg("starting bootstrap")
 
-	if err := engine.OpenDBs(homePath); err != nil {
+	if err := engine.OpenDBs(); err != nil {
 		return fmt.Errorf("failed to open dbs in engine: %w", err)
 	}
 
-	// TODO: handle error
-	defer engine.CloseDBs()
+	defer func() {
+		err := engine.CloseDBs()
+		_ = err
+	}()
 
 	gt100, err := utils.IsFileGreaterThanOrEqualTo100MB(engine.GetGenesisPath())
 	if err != nil {

--- a/cmd/ksync/commands/blocksync.go
+++ b/cmd/ksync/commands/blocksync.go
@@ -83,15 +83,15 @@ var blockSyncCmd = &cobra.Command{
 			return
 		}
 
-		defaultEngine := engines.EngineFactory(engine)
+		defaultEngine := engines.EngineFactory(engine, homePath, rpcServerPort)
 		if reset {
-			if err := defaultEngine.ResetAll(homePath, true); err != nil {
+			if err := defaultEngine.ResetAll(true); err != nil {
 				logger.Error().Msg(fmt.Sprintf("failed to reset tendermint application: %s", err))
 				os.Exit(1)
 			}
 		}
 
-		if err := defaultEngine.OpenDBs(homePath); err != nil {
+		if err := defaultEngine.OpenDBs(); err != nil {
 			logger.Error().Msg(fmt.Sprintf("failed to open dbs in engine: %s", err))
 			os.Exit(1)
 		}
@@ -110,13 +110,8 @@ var blockSyncCmd = &cobra.Command{
 
 		sources.IsBinaryRecommendedVersion(binaryPath, registryUrl, source, continuationHeight, !y)
 
-		consensusEngine := engines.EngineSourceFactory(engine, registryUrl, source, continuationHeight)
+		consensusEngine := engines.EngineSourceFactory(engine, homePath, registryUrl, source, rpcServerPort, continuationHeight)
 
-		// TODO: move to blocksync
-		//if rpcServer {
-		//	go consensusEngine.StartRPCServer(rpcServerPort)
-		//}
-
-		blocksync.StartBlockSyncWithBinary(consensusEngine, binaryPath, homePath, chainId, chainRest, storageRest, nil, &bId, targetHeight, backupCfg, appFlags, optOut, debug)
+		blocksync.StartBlockSyncWithBinary(consensusEngine, binaryPath, homePath, chainId, chainRest, storageRest, nil, &bId, targetHeight, backupCfg, appFlags, rpcServer, optOut, debug)
 	},
 }

--- a/cmd/ksync/commands/blocksync.go
+++ b/cmd/ksync/commands/blocksync.go
@@ -112,20 +112,11 @@ var blockSyncCmd = &cobra.Command{
 
 		consensusEngine := engines.EngineSourceFactory(engine, registryUrl, source, continuationHeight)
 
-		if err := consensusEngine.OpenDBs(homePath); err != nil {
-			logger.Error().Msg(fmt.Sprintf("failed to open dbs in engine: %s", err))
-			os.Exit(1)
-		}
-
-		if rpcServer {
-			go consensusEngine.StartRPCServer(rpcServerPort)
-		}
+		// TODO: move to blocksync
+		//if rpcServer {
+		//	go consensusEngine.StartRPCServer(rpcServerPort)
+		//}
 
 		blocksync.StartBlockSyncWithBinary(consensusEngine, binaryPath, homePath, chainId, chainRest, storageRest, nil, &bId, targetHeight, backupCfg, appFlags, optOut, debug)
-
-		if err := consensusEngine.CloseDBs(); err != nil {
-			logger.Error().Msg(fmt.Sprintf("failed to close dbs in engine: %s", err))
-			os.Exit(1)
-		}
 	},
 }

--- a/cmd/ksync/commands/heightsync.go
+++ b/cmd/ksync/commands/heightsync.go
@@ -71,15 +71,15 @@ var heightSyncCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		defaultEngine := engines.EngineFactory(engine)
+		defaultEngine := engines.EngineFactory(engine, homePath, rpcServerPort)
 		if reset {
-			if err := defaultEngine.ResetAll(homePath, true); err != nil {
+			if err := defaultEngine.ResetAll(true); err != nil {
 				logger.Error().Msg(fmt.Sprintf("failed to reset tendermint application: %s", err))
 				os.Exit(1)
 			}
 		}
 
-		if err := defaultEngine.OpenDBs(homePath); err != nil {
+		if err := defaultEngine.OpenDBs(); err != nil {
 			logger.Error().Msg(fmt.Sprintf("failed to open dbs in engine: %s", err))
 			os.Exit(1)
 		}
@@ -120,18 +120,8 @@ var heightSyncCmd = &cobra.Command{
 
 		sources.IsBinaryRecommendedVersion(binaryPath, registryUrl, source, continuationHeight, !y)
 
-		consensusEngine := engines.EngineSourceFactory(engine, registryUrl, source, continuationHeight)
-
-		if err := consensusEngine.OpenDBs(homePath); err != nil {
-			logger.Error().Msg(fmt.Sprintf("failed to open dbs in engine: %s", err))
-			os.Exit(1)
-		}
+		consensusEngine := engines.EngineSourceFactory(engine, homePath, registryUrl, source, rpcServerPort, continuationHeight)
 
 		heightsync.StartHeightSyncWithBinary(consensusEngine, binaryPath, homePath, chainId, chainRest, storageRest, sId, &bId, targetHeight, snapshotBundleId, snapshotHeight, appFlags, optOut, debug)
-
-		if err := consensusEngine.CloseDBs(); err != nil {
-			logger.Error().Msg(fmt.Sprintf("failed to close dbs in engine: %s", err))
-			os.Exit(1)
-		}
 	},
 }

--- a/cmd/ksync/commands/resetall.go
+++ b/cmd/ksync/commands/resetall.go
@@ -29,7 +29,7 @@ var resetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.TrackResetEvent(optOut)
 
-		if err := engines.EngineFactory(engine).ResetAll(homePath, keepAddrBook); err != nil {
+		if err := engines.EngineFactory(engine, homePath, rpcServerPort).ResetAll(keepAddrBook); err != nil {
 			logger.Error().Msg(fmt.Sprintf("failed to reset tendermint application: %s", err))
 			os.Exit(1)
 		}

--- a/cmd/ksync/commands/serveblocks.go
+++ b/cmd/ksync/commands/serveblocks.go
@@ -33,6 +33,7 @@ func init() {
 
 	serveBlocksCmd.Flags().Int64Var(&blockRpcReqTimeout, "block-rpc-req-timeout", utils.RequestBlocksTimeoutMS, "port where the block api server will be started")
 
+	serveBlocksCmd.Flags().BoolVar(&rpcServer, "rpc-server", true, "rpc server serving /status, /block and /block_results")
 	serveBlocksCmd.Flags().Int64Var(&rpcServerPort, "rpc-server-port", utils.DefaultRpcServerPort, "port where the rpc server will be started")
 
 	serveBlocksCmd.Flags().StringVarP(&source, "source", "s", "", "chain-id of the source")
@@ -69,15 +70,15 @@ var serveBlocksCmd = &cobra.Command{
 			return
 		}
 
-		defaultEngine := engines.EngineFactory(engine)
+		defaultEngine := engines.EngineFactory(engine, homePath, rpcServerPort)
 		if reset {
-			if err := defaultEngine.ResetAll(homePath, true); err != nil {
+			if err := defaultEngine.ResetAll(true); err != nil {
 				logger.Error().Msg(fmt.Sprintf("failed to reset tendermint application: %s", err))
 				os.Exit(1)
 			}
 		}
 
-		if err := defaultEngine.OpenDBs(homePath); err != nil {
+		if err := defaultEngine.OpenDBs(); err != nil {
 			logger.Error().Msg(fmt.Sprintf("failed to open dbs in engine: %s", err))
 			os.Exit(1)
 		}
@@ -94,20 +95,8 @@ var serveBlocksCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		consensusEngine := engines.EngineSourceFactory(engine, registryUrl, source, continuationHeight)
+		consensusEngine := engines.EngineSourceFactory(engine, homePath, registryUrl, source, rpcServerPort, continuationHeight)
 
-		if err := consensusEngine.OpenDBs(homePath); err != nil {
-			logger.Error().Msg(fmt.Sprintf("failed to open dbs in engine: %s", err))
-			os.Exit(1)
-		}
-
-		go consensusEngine.StartRPCServer(rpcServerPort)
-
-		blocksync.StartBlockSyncWithBinary(consensusEngine, binaryPath, homePath, chainId, chainRest, storageRest, &blockRpcConfig, nil, targetHeight, backupCfg, appFlags, optOut, debug)
-
-		if err := consensusEngine.CloseDBs(); err != nil {
-			logger.Error().Msg(fmt.Sprintf("failed to close dbs in engine: %s", err))
-			os.Exit(1)
-		}
+		blocksync.StartBlockSyncWithBinary(consensusEngine, binaryPath, homePath, chainId, chainRest, storageRest, &blockRpcConfig, nil, targetHeight, backupCfg, appFlags, rpcServer, optOut, debug)
 	},
 }

--- a/cmd/ksync/commands/statesync.go
+++ b/cmd/ksync/commands/statesync.go
@@ -68,9 +68,9 @@ var stateSyncCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		defaultEngine := engines.EngineFactory(engine)
+		defaultEngine := engines.EngineFactory(engine, homePath, rpcServerPort)
 		if reset {
-			if err := defaultEngine.ResetAll(homePath, true); err != nil {
+			if err := defaultEngine.ResetAll(true); err != nil {
 				logger.Error().Msg(fmt.Sprintf("failed to reset tendermint application: %s", err))
 				os.Exit(1)
 			}
@@ -85,18 +85,8 @@ var stateSyncCmd = &cobra.Command{
 
 		sources.IsBinaryRecommendedVersion(binaryPath, registryUrl, source, snapshotHeight, !y)
 
-		consensusEngine := engines.EngineSourceFactory(engine, registryUrl, source, snapshotHeight)
-
-		if err := consensusEngine.OpenDBs(homePath); err != nil {
-			logger.Error().Msg(fmt.Sprintf("failed to open dbs in engine: %s", err))
-			os.Exit(1)
-		}
+		consensusEngine := engines.EngineSourceFactory(engine, homePath, registryUrl, source, rpcServerPort, snapshotHeight)
 
 		statesync.StartStateSyncWithBinary(consensusEngine, binaryPath, chainId, chainRest, storageRest, sId, targetHeight, snapshotBundleId, snapshotHeight, appFlags, optOut, debug)
-
-		if err := consensusEngine.CloseDBs(); err != nil {
-			logger.Error().Msg(fmt.Sprintf("failed to close dbs in engine: %s", err))
-			os.Exit(1)
-		}
 	},
 }

--- a/engines/celestia-core-v34/celestiacore.go
+++ b/engines/celestia-core-v34/celestiacore.go
@@ -63,8 +63,8 @@ func (engine *Engine) GetName() string {
 	return utils.EngineCelestiaCoreV34
 }
 
-func (engine *Engine) OpenDBs() error {
-	if engine.areDBsOpen {
+func (engine *Engine) LoadConfig() error {
+	if engine.config != nil {
 		return nil
 	}
 
@@ -74,8 +74,19 @@ func (engine *Engine) OpenDBs() error {
 	}
 
 	engine.config = config
+	return nil
+}
 
-	if err := utils.FormatGenesisFile(config.GenesisFile()); err != nil {
+func (engine *Engine) OpenDBs() error {
+	if engine.areDBsOpen {
+		return nil
+	}
+
+	if err := engine.LoadConfig(); err != nil {
+		return err
+	}
+
+	if err := utils.FormatGenesisFile(engine.config.GenesisFile()); err != nil {
 		return fmt.Errorf("failed to format genesis file: %w", err)
 	}
 
@@ -86,15 +97,15 @@ func (engine *Engine) OpenDBs() error {
 	engine.genDoc = genDoc
 
 	privValidatorKey, err := privval.LoadFilePVEmptyState(
-		config.PrivValidatorKeyFile(),
-		config.PrivValidatorStateFile(),
+		engine.config.PrivValidatorKeyFile(),
+		engine.config.PrivValidatorStateFile(),
 	).GetPubKey()
 	if err != nil {
 		return fmt.Errorf("failed to load validator key file: %w", err)
 	}
 	engine.privValidatorKey = privValidatorKey
 
-	blockDB, blockStore, err := GetBlockstoreDBs(config)
+	blockDB, blockStore, err := GetBlockstoreDBs(engine.config)
 	if err != nil {
 		return fmt.Errorf("failed to open blockDB: %w", err)
 	}
@@ -102,7 +113,7 @@ func (engine *Engine) OpenDBs() error {
 	engine.blockDB = blockDB
 	engine.blockStore = blockStore
 
-	stateDB, stateStore, err := GetStateDBs(config)
+	stateDB, stateStore, err := GetStateDBs(engine.config)
 	if err != nil {
 		return fmt.Errorf("failed to open stateDB: %w", err)
 	}

--- a/engines/celestia-core-v34/celestiacore.go
+++ b/engines/celestia-core-v34/celestiacore.go
@@ -37,8 +37,9 @@ var (
 )
 
 type Engine struct {
-	homePath string
-	config   *cfg.Config
+	homePath   string
+	areDBsOpen bool
+	config     *cfg.Config
 
 	blockDB    db.DB
 	blockStore *tmStore.BlockStore
@@ -63,6 +64,10 @@ func (engine *Engine) GetName() string {
 
 func (engine *Engine) OpenDBs(homePath string) error {
 	engine.homePath = homePath
+
+	if engine.areDBsOpen {
+		return nil
+	}
 
 	config, err := LoadConfig(engine.homePath)
 	if err != nil {
@@ -106,10 +111,15 @@ func (engine *Engine) OpenDBs(homePath string) error {
 	engine.stateDB = stateDB
 	engine.stateStore = stateStore
 
+	engine.areDBsOpen = true
 	return nil
 }
 
 func (engine *Engine) CloseDBs() error {
+	if !engine.areDBsOpen {
+		return nil
+	}
+
 	if err := engine.blockDB.Close(); err != nil {
 		return fmt.Errorf("failed to close blockDB: %w", err)
 	}
@@ -118,6 +128,7 @@ func (engine *Engine) CloseDBs() error {
 		return fmt.Errorf("failed to close stateDB: %w", err)
 	}
 
+	engine.areDBsOpen = false
 	return nil
 }
 

--- a/engines/celestia-core-v34/celestiacore.go
+++ b/engines/celestia-core-v34/celestiacore.go
@@ -205,10 +205,11 @@ func (engine *Engine) GetContinuationHeight() (int64, error) {
 }
 
 func (engine *Engine) DoHandshake() error {
-	defaultDocProvider := nm.DefaultGenesisDocProviderFunc(engine.config)
-	state, genDoc, err := nm.LoadStateFromDBOrGenesisDocProvider(engine.stateDB, defaultDocProvider)
+	state, err := tmState.NewStore(engine.stateDB, tmState.StoreOptions{
+		DiscardABCIResponses: false,
+	}).LoadFromDBOrGenesisDoc(engine.genDoc)
 	if err != nil {
-		return fmt.Errorf("failed to load state and genDoc: %w", err)
+		return fmt.Errorf("failed to load state from genDoc: %w", err)
 	}
 
 	eventBus, err := CreateAndStartEventBus()
@@ -216,7 +217,7 @@ func (engine *Engine) DoHandshake() error {
 		return fmt.Errorf("failed to start event bus: %w", err)
 	}
 
-	if err := DoHandshake(engine.stateStore, state, engine.blockStore, genDoc, eventBus, engine.proxyApp); err != nil {
+	if err := DoHandshake(engine.stateStore, state, engine.blockStore, engine.genDoc, eventBus, engine.proxyApp); err != nil {
 		return fmt.Errorf("failed to do handshake: %w", err)
 	}
 

--- a/engines/cometbft-v37/cometbft.go
+++ b/engines/cometbft-v37/cometbft.go
@@ -204,10 +204,11 @@ func (engine *Engine) GetContinuationHeight() (int64, error) {
 }
 
 func (engine *Engine) DoHandshake() error {
-	defaultDocProvider := nm.DefaultGenesisDocProviderFunc(engine.config)
-	state, genDoc, err := nm.LoadStateFromDBOrGenesisDocProvider(engine.stateDB, defaultDocProvider)
+	state, err := tmState.NewStore(engine.stateDB, tmState.StoreOptions{
+		DiscardABCIResponses: false,
+	}).LoadFromDBOrGenesisDoc(engine.genDoc)
 	if err != nil {
-		return fmt.Errorf("failed to load state and genDoc: %w", err)
+		return fmt.Errorf("failed to load state from genDoc: %w", err)
 	}
 
 	eventBus, err := CreateAndStartEventBus()
@@ -215,7 +216,7 @@ func (engine *Engine) DoHandshake() error {
 		return fmt.Errorf("failed to start event bus: %w", err)
 	}
 
-	if err := DoHandshake(engine.stateStore, state, engine.blockStore, genDoc, eventBus, engine.proxyApp); err != nil {
+	if err := DoHandshake(engine.stateStore, state, engine.blockStore, engine.genDoc, eventBus, engine.proxyApp); err != nil {
 		return fmt.Errorf("failed to do handshake: %w", err)
 	}
 

--- a/engines/cometbft-v37/cometbft.go
+++ b/engines/cometbft-v37/cometbft.go
@@ -36,8 +36,9 @@ var (
 )
 
 type Engine struct {
-	homePath string
-	config   *cfg.Config
+	homePath   string
+	areDBsOpen bool
+	config     *cfg.Config
 
 	blockDB    db.DB
 	blockStore *tmStore.BlockStore
@@ -62,6 +63,10 @@ func (engine *Engine) GetName() string {
 
 func (engine *Engine) OpenDBs(homePath string) error {
 	engine.homePath = homePath
+
+	if engine.areDBsOpen {
+		return nil
+	}
 
 	config, err := LoadConfig(engine.homePath)
 	if err != nil {
@@ -105,10 +110,15 @@ func (engine *Engine) OpenDBs(homePath string) error {
 	engine.stateDB = stateDB
 	engine.stateStore = stateStore
 
+	engine.areDBsOpen = true
 	return nil
 }
 
 func (engine *Engine) CloseDBs() error {
+	if !engine.areDBsOpen {
+		return nil
+	}
+
 	if err := engine.blockDB.Close(); err != nil {
 		return fmt.Errorf("failed to close blockDB: %w", err)
 	}
@@ -117,6 +127,7 @@ func (engine *Engine) CloseDBs() error {
 		return fmt.Errorf("failed to close stateDB: %w", err)
 	}
 
+	engine.areDBsOpen = false
 	return nil
 }
 

--- a/engines/cometbft-v38/cometbft.go
+++ b/engines/cometbft-v38/cometbft.go
@@ -206,10 +206,11 @@ func (engine *Engine) GetContinuationHeight() (int64, error) {
 }
 
 func (engine *Engine) DoHandshake() error {
-	defaultDocProvider := nm.DefaultGenesisDocProviderFunc(engine.config)
-	state, genDoc, err := nm.LoadStateFromDBOrGenesisDocProvider(engine.stateDB, defaultDocProvider)
+	state, err := tmState.NewStore(engine.stateDB, tmState.StoreOptions{
+		DiscardABCIResponses: false,
+	}).LoadFromDBOrGenesisDoc(engine.genDoc)
 	if err != nil {
-		return fmt.Errorf("failed to load state and genDoc: %w", err)
+		return fmt.Errorf("failed to load state from genDoc: %w", err)
 	}
 
 	eventBus, err := CreateAndStartEventBus()
@@ -217,7 +218,7 @@ func (engine *Engine) DoHandshake() error {
 		return fmt.Errorf("failed to start event bus: %w", err)
 	}
 
-	if err := DoHandshake(engine.stateStore, state, engine.blockStore, genDoc, eventBus, engine.proxyApp); err != nil {
+	if err := DoHandshake(engine.stateStore, state, engine.blockStore, engine.genDoc, eventBus, engine.proxyApp); err != nil {
 		return fmt.Errorf("failed to do handshake: %w", err)
 	}
 

--- a/engines/cometbft-v38/cometbft.go
+++ b/engines/cometbft-v38/cometbft.go
@@ -64,8 +64,8 @@ func (engine *Engine) GetName() string {
 	return utils.EngineCometBFTV38
 }
 
-func (engine *Engine) OpenDBs() error {
-	if engine.areDBsOpen {
+func (engine *Engine) LoadConfig() error {
+	if engine.config != nil {
 		return nil
 	}
 
@@ -75,8 +75,19 @@ func (engine *Engine) OpenDBs() error {
 	}
 
 	engine.config = config
+	return nil
+}
 
-	if err := utils.FormatGenesisFile(config.GenesisFile()); err != nil {
+func (engine *Engine) OpenDBs() error {
+	if engine.areDBsOpen {
+		return nil
+	}
+
+	if err := engine.LoadConfig(); err != nil {
+		return err
+	}
+
+	if err := utils.FormatGenesisFile(engine.config.GenesisFile()); err != nil {
 		return fmt.Errorf("failed to format genesis file: %w", err)
 	}
 
@@ -87,15 +98,15 @@ func (engine *Engine) OpenDBs() error {
 	engine.genDoc = genDoc
 
 	privValidatorKey, err := privval.LoadFilePVEmptyState(
-		config.PrivValidatorKeyFile(),
-		config.PrivValidatorStateFile(),
+		engine.config.PrivValidatorKeyFile(),
+		engine.config.PrivValidatorStateFile(),
 	).GetPubKey()
 	if err != nil {
 		return fmt.Errorf("failed to load validator key file: %w", err)
 	}
 	engine.privValidatorKey = privValidatorKey
 
-	blockDB, blockStore, err := GetBlockstoreDBs(config)
+	blockDB, blockStore, err := GetBlockstoreDBs(engine.config)
 	if err != nil {
 		return fmt.Errorf("failed to open blockDB: %w", err)
 	}
@@ -103,7 +114,7 @@ func (engine *Engine) OpenDBs() error {
 	engine.blockDB = blockDB
 	engine.blockStore = blockStore
 
-	stateDB, stateStore, err := GetStateDBs(config)
+	stateDB, stateStore, err := GetStateDBs(engine.config)
 	if err != nil {
 		return fmt.Errorf("failed to open stateDB: %w", err)
 	}

--- a/engines/engines.go
+++ b/engines/engines.go
@@ -17,10 +17,10 @@ var (
 	logger = utils.KsyncLogger("engines")
 )
 
-func EngineSourceFactory(engine, registryUrl, source string, continuationHeight int64) types.Engine {
+func EngineSourceFactory(engine, homePath, registryUrl, source string, rpcServerPort, continuationHeight int64) types.Engine {
 	// if the engine was specified by the user or the source is empty we determine the engine by the engine input
 	if engine != "" || source == "" {
-		return EngineFactory(engine)
+		return EngineFactory(engine, homePath, rpcServerPort)
 	}
 
 	entry, err := helpers.GetSourceRegistryEntry(registryUrl, source)
@@ -44,46 +44,46 @@ func EngineSourceFactory(engine, registryUrl, source string, continuationHeight 
 	}
 
 	logger.Info().Msg(fmt.Sprintf("using \"%s\" as consensus engine", engine))
-	return EngineFactory(engine)
+	return EngineFactory(engine, homePath, rpcServerPort)
 }
 
-func EngineFactory(engine string) types.Engine {
+func EngineFactory(engine, homePath string, rpcServerPort int64) types.Engine {
 	switch engine {
 	case "":
-		return &cometbft_v38.Engine{}
+		return &cometbft_v38.Engine{HomePath: homePath, RpcServerPort: rpcServerPort}
 	case utils.EngineTendermintV34:
-		return &tendermint_v34.Engine{}
+		return &tendermint_v34.Engine{HomePath: homePath, RpcServerPort: rpcServerPort}
 	case utils.EngineCometBFTV37:
-		return &cometbft_v37.Engine{}
+		return &cometbft_v37.Engine{HomePath: homePath, RpcServerPort: rpcServerPort}
 	case utils.EngineCometBFTV38:
-		return &cometbft_v38.Engine{}
+		return &cometbft_v38.Engine{HomePath: homePath, RpcServerPort: rpcServerPort}
 	case utils.EngineCelestiaCoreV34:
-		return &celestia_core_v34.Engine{}
+		return &celestia_core_v34.Engine{HomePath: homePath, RpcServerPort: rpcServerPort}
 
 	// These engines are deprecated and will be removed soon
 	case utils.EngineTendermintV34Legacy:
 		logger.Warn().Msg(fmt.Sprintf("engine %s is deprecated and will soon be removed, use %s instead", utils.EngineTendermintV34Legacy, utils.EngineTendermintV34))
-		return &tendermint_v34.Engine{}
+		return &tendermint_v34.Engine{HomePath: homePath, RpcServerPort: rpcServerPort}
 	case utils.EngineCometBFTV37Legacy:
 		logger.Warn().Msg(fmt.Sprintf("engine %s is deprecated and will soon be removed, use %s instead", utils.EngineCometBFTV37Legacy, utils.EngineCometBFTV37))
-		return &cometbft_v37.Engine{}
+		return &cometbft_v37.Engine{HomePath: homePath, RpcServerPort: rpcServerPort}
 	case utils.EngineCometBFTV38Legacy:
 		logger.Warn().Msg(fmt.Sprintf("engine %s is deprecated and will soon be removed, use %s instead", utils.EngineCometBFTV38Legacy, utils.EngineCometBFTV38))
-		return &cometbft_v38.Engine{}
+		return &cometbft_v38.Engine{HomePath: homePath, RpcServerPort: rpcServerPort}
 	case utils.EngineCelestiaCoreV34Legacy:
 		logger.Warn().Msg(fmt.Sprintf("engine %s is deprecated and will soon be removed, use %s instead", utils.EngineCelestiaCoreV34Legacy, utils.EngineCelestiaCoreV34))
-		return &celestia_core_v34.Engine{}
+		return &celestia_core_v34.Engine{HomePath: homePath, RpcServerPort: rpcServerPort}
 
 	// These engines are deprecated and will be removed soon
 	case utils.EngineTendermintLegacy:
 		logger.Warn().Msg(fmt.Sprintf("engine %s is deprecated and will soon be removed, use %s instead", utils.EngineTendermintLegacy, utils.EngineTendermintV34))
-		return &tendermint_v34.Engine{}
+		return &tendermint_v34.Engine{HomePath: homePath, RpcServerPort: rpcServerPort}
 	case utils.EngineCometBFTLegacy:
 		logger.Warn().Msg(fmt.Sprintf("engine %s is deprecated and will soon be removed, use %s or %s instead", utils.EngineCometBFTLegacy, utils.EngineCometBFTV37, utils.EngineCometBFTV38))
-		return &cometbft_v37.Engine{}
+		return &cometbft_v37.Engine{HomePath: homePath, RpcServerPort: rpcServerPort}
 	case utils.EngineCelestiaCoreLegacy:
 		logger.Warn().Msg(fmt.Sprintf("engine %s is deprecated and will soon be removed, use %s instead", utils.EngineCelestiaCoreLegacy, utils.EngineCelestiaCoreV34))
-		return &celestia_core_v34.Engine{}
+		return &celestia_core_v34.Engine{HomePath: homePath, RpcServerPort: rpcServerPort}
 	default:
 		logger.Error().Msg(fmt.Sprintf("engine %s not found, run \"ksync engines\" to list all available engines", engine))
 		os.Exit(1)

--- a/engines/tendermint-v34/tendermint.go
+++ b/engines/tendermint-v34/tendermint.go
@@ -199,10 +199,9 @@ func (engine *Engine) GetContinuationHeight() (int64, error) {
 }
 
 func (engine *Engine) DoHandshake() error {
-	defaultDocProvider := nm.DefaultGenesisDocProviderFunc(engine.config)
-	state, genDoc, err := nm.LoadStateFromDBOrGenesisDocProvider(engine.stateDB, defaultDocProvider)
+	state, err := tmState.NewStore(engine.stateDB).LoadFromDBOrGenesisDoc(engine.genDoc)
 	if err != nil {
-		return fmt.Errorf("failed to load state and genDoc: %w", err)
+		return fmt.Errorf("failed to load state from genDoc: %w", err)
 	}
 
 	eventBus, err := CreateAndStartEventBus()
@@ -210,7 +209,7 @@ func (engine *Engine) DoHandshake() error {
 		return fmt.Errorf("failed to start event bus: %w", err)
 	}
 
-	if err := DoHandshake(engine.stateStore, state, engine.blockStore, genDoc, eventBus, engine.proxyApp); err != nil {
+	if err := DoHandshake(engine.stateStore, state, engine.blockStore, engine.genDoc, eventBus, engine.proxyApp); err != nil {
 		return fmt.Errorf("failed to do handshake: %w", err)
 	}
 

--- a/engines/tendermint-v34/tendermint.go
+++ b/engines/tendermint-v34/tendermint.go
@@ -37,8 +37,9 @@ var (
 )
 
 type Engine struct {
-	homePath string
-	config   *cfg.Config
+	homePath   string
+	areDBsOpen bool
+	config     *cfg.Config
 
 	blockDB    db.DB
 	blockStore *tmStore.BlockStore
@@ -63,6 +64,10 @@ func (engine *Engine) GetName() string {
 
 func (engine *Engine) OpenDBs(homePath string) error {
 	engine.homePath = homePath
+
+	if engine.areDBsOpen {
+		return nil
+	}
 
 	config, err := LoadConfig(engine.homePath)
 	if err != nil {
@@ -106,10 +111,15 @@ func (engine *Engine) OpenDBs(homePath string) error {
 	engine.stateDB = stateDB
 	engine.stateStore = stateStore
 
+	engine.areDBsOpen = true
 	return nil
 }
 
 func (engine *Engine) CloseDBs() error {
+	if !engine.areDBsOpen {
+		return nil
+	}
+
 	if err := engine.blockDB.Close(); err != nil {
 		return fmt.Errorf("failed to close blockDB: %w", err)
 	}
@@ -118,6 +128,7 @@ func (engine *Engine) CloseDBs() error {
 		return fmt.Errorf("failed to close stateDB: %w", err)
 	}
 
+	engine.areDBsOpen = false
 	return nil
 }
 

--- a/engines/tendermint-v34/tendermint.go
+++ b/engines/tendermint-v34/tendermint.go
@@ -37,9 +37,10 @@ var (
 )
 
 type Engine struct {
-	homePath   string
-	areDBsOpen bool
-	config     *cfg.Config
+	HomePath      string
+	RpcServerPort int64
+	areDBsOpen    bool
+	config        *cfg.Config
 
 	blockDB    db.DB
 	blockStore *tmStore.BlockStore
@@ -62,14 +63,12 @@ func (engine *Engine) GetName() string {
 	return utils.EngineTendermintV34
 }
 
-func (engine *Engine) OpenDBs(homePath string) error {
-	engine.homePath = homePath
-
+func (engine *Engine) OpenDBs() error {
 	if engine.areDBsOpen {
 		return nil
 	}
 
-	config, err := LoadConfig(engine.homePath)
+	config, err := LoadConfig(engine.HomePath)
 	if err != nil {
 		return fmt.Errorf("failed to load config.toml: %w", err)
 	}
@@ -133,7 +132,7 @@ func (engine *Engine) CloseDBs() error {
 }
 
 func (engine *Engine) GetHomePath() string {
-	return engine.homePath
+	return engine.HomePath
 }
 
 func (engine *Engine) GetProxyAppAddress() string {
@@ -503,7 +502,7 @@ func (engine *Engine) GetBlock(height int64) ([]byte, error) {
 	return json.Marshal(block)
 }
 
-func (engine *Engine) StartRPCServer(port int64) {
+func (engine *Engine) StartRPCServer() {
 	// wait until all reactors have been booted
 	for engine.blockExecutor == nil {
 		time.Sleep(1000)
@@ -561,7 +560,7 @@ func (engine *Engine) StartRPCServer(port int64) {
 	config := rpcserver.DefaultConfig()
 
 	rpcserver.RegisterRPCFuncs(mux, routes, rpcLogger)
-	listener, err := rpcserver.Listen(fmt.Sprintf("tcp://127.0.0.1:%d", port), config)
+	listener, err := rpcserver.Listen(fmt.Sprintf("tcp://127.0.0.1:%d", engine.RpcServerPort), config)
 	if err != nil {
 		tmLogger.Error(fmt.Sprintf("failed to get rpc listener: %s", err))
 		return
@@ -734,8 +733,8 @@ func (engine *Engine) PruneBlocks(toHeight int64) error {
 	return nil
 }
 
-func (engine *Engine) ResetAll(homePath string, keepAddrBook bool) error {
-	config, err := LoadConfig(homePath)
+func (engine *Engine) ResetAll(keepAddrBook bool) error {
+	config, err := LoadConfig(engine.HomePath)
 	if err != nil {
 		return fmt.Errorf("failed to load config.toml: %w", err)
 	}

--- a/engines/tendermint-v34/tendermint.go
+++ b/engines/tendermint-v34/tendermint.go
@@ -63,8 +63,8 @@ func (engine *Engine) GetName() string {
 	return utils.EngineTendermintV34
 }
 
-func (engine *Engine) OpenDBs() error {
-	if engine.areDBsOpen {
+func (engine *Engine) LoadConfig() error {
+	if engine.config != nil {
 		return nil
 	}
 
@@ -74,8 +74,19 @@ func (engine *Engine) OpenDBs() error {
 	}
 
 	engine.config = config
+	return nil
+}
 
-	if err := utils.FormatGenesisFile(config.GenesisFile()); err != nil {
+func (engine *Engine) OpenDBs() error {
+	if engine.areDBsOpen {
+		return nil
+	}
+
+	if err := engine.LoadConfig(); err != nil {
+		return err
+	}
+
+	if err := utils.FormatGenesisFile(engine.config.GenesisFile()); err != nil {
 		return fmt.Errorf("failed to format genesis file: %w", err)
 	}
 
@@ -86,15 +97,15 @@ func (engine *Engine) OpenDBs() error {
 	engine.genDoc = genDoc
 
 	privValidatorKey, err := privval.LoadFilePVEmptyState(
-		config.PrivValidatorKeyFile(),
-		config.PrivValidatorStateFile(),
+		engine.config.PrivValidatorKeyFile(),
+		engine.config.PrivValidatorStateFile(),
 	).GetPubKey()
 	if err != nil {
 		return fmt.Errorf("failed to load validator key file: %w", err)
 	}
 	engine.privValidatorKey = privValidatorKey
 
-	blockDB, blockStore, err := GetBlockstoreDBs(config)
+	blockDB, blockStore, err := GetBlockstoreDBs(engine.config)
 	if err != nil {
 		return fmt.Errorf("failed to open blockDB: %w", err)
 	}
@@ -102,7 +113,7 @@ func (engine *Engine) OpenDBs() error {
 	engine.blockDB = blockDB
 	engine.blockStore = blockStore
 
-	stateDB, stateStore, err := GetStateDBs(config)
+	stateDB, stateStore, err := GetStateDBs(engine.config)
 	if err != nil {
 		return fmt.Errorf("failed to open stateDB: %w", err)
 	}

--- a/sources/version.go
+++ b/sources/version.go
@@ -40,7 +40,9 @@ func IsBinaryRecommendedVersion(binaryPath, registryUrl, source string, continua
 		os.Exit(1)
 	}
 
-	binaryVersion := fmt.Sprintf("v%s", strings.TrimSuffix(string(out), "\n"))
+	binaryVersion := strings.TrimSuffix(string(out), "\n")
+	binaryVersionFormatted := fmt.Sprintf("v%s", binaryVersion)
+
 	var recommendedVersion string
 
 	entry, err := helpers.GetSourceRegistryEntry(registryUrl, source)
@@ -63,7 +65,7 @@ func IsBinaryRecommendedVersion(binaryPath, registryUrl, source string, continua
 		recommendedVersion = upgrade.RecommendedVersion
 	}
 
-	if binaryVersion == recommendedVersion {
+	if binaryVersion == recommendedVersion || binaryVersionFormatted == recommendedVersion {
 		return
 	}
 

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -6,6 +6,9 @@ type Engine interface {
 	// GetName gets the engine name
 	GetName() string
 
+	// LoadConfig loads and sets the config
+	LoadConfig() error
+
 	// OpenDBs opens the relevant blockstore and state DBs
 	OpenDBs() error
 

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -7,7 +7,7 @@ type Engine interface {
 	GetName() string
 
 	// OpenDBs opens the relevant blockstore and state DBs
-	OpenDBs(homePath string) error
+	OpenDBs() error
 
 	// CloseDBs closes the relevant blockstore and state DBs
 	CloseDBs() error
@@ -74,7 +74,7 @@ type Engine interface {
 
 	// StartRPCServer spins up a basic rpc server of the engine which serves
 	// /status, /block and /block_results
-	StartRPCServer(port int64)
+	StartRPCServer()
 
 	// GetState rebuilds the requested state from the blockstore and state.db
 	GetState(height int64) ([]byte, error)
@@ -97,5 +97,5 @@ type Engine interface {
 
 	// ResetAll removes all the data and WAL, reset this node's validator
 	// to genesis state
-	ResetAll(homePath string, keepAddrBook bool) error
+	ResetAll(keepAddrBook bool) error
 }

--- a/utils/binaries.go
+++ b/utils/binaries.go
@@ -65,6 +65,10 @@ func StartBinaryProcessForDB(engine types.Engine, binaryPath string, debug bool,
 		startArgs = append(startArgs, "run")
 	}
 
+	if err := engine.LoadConfig(); err != nil {
+		return processId, fmt.Errorf("failed to load engine config: %w", err)
+	}
+
 	baseArgs := append([]string{
 		"start",
 		"--home",


### PR DESCRIPTION
For some cosmos-sdk versions like `v0.47.8` the app binary shortly accesses the blockstore.db although it is started with `--with-tendermint=false`, resulting in a panic that the database is locked. This PR addresses this issue by rearranging the boot order of the binaries by first starting the app binary so it can open and close the blockstore.db (to retrieve the chain-id) and only after that will KSYNC open the blockstore.db for itself and lock it for the rest of the sync.