### PR TITLE
chore: autodetect source from genesis file

### DIFF
--- a/cmd/ksync/commands/blocksync.go
+++ b/cmd/ksync/commands/blocksync.go
@@ -66,9 +66,21 @@ var blockSyncCmd = &cobra.Command{
 			logger.Info().Msg("To start the syncing process, start your chain binary with --with-tendermint=false")
 		}
 
-		// if no home path was given get the default one
 		if homePath == "" {
 			homePath = utils.GetHomePathFromBinary(binaryPath)
+			logger.Info().Msgf("Loaded home path \"%s\" from binary path", homePath)
+		}
+
+		defaultEngine := engines.EngineFactory(engine, homePath, rpcServerPort)
+
+		if source == "" {
+			s, err := defaultEngine.GetChainId()
+			if err != nil {
+				logger.Error().Msgf("Failed to load chain-id from engine: %s", err.Error())
+				os.Exit(1)
+			}
+			source = s
+			logger.Info().Msgf("Loaded source \"%s\" from genesis file", source)
 		}
 
 		bId, _, err := sources.GetPoolIds(chainId, source, blockPoolId, "", registryUrl, true, false)
@@ -83,7 +95,6 @@ var blockSyncCmd = &cobra.Command{
 			return
 		}
 
-		defaultEngine := engines.EngineFactory(engine, homePath, rpcServerPort)
 		if reset {
 			if err := defaultEngine.ResetAll(true); err != nil {
 				logger.Error().Msg(fmt.Sprintf("failed to reset tendermint application: %s", err))

--- a/cmd/ksync/commands/heightsync.go
+++ b/cmd/ksync/commands/heightsync.go
@@ -65,13 +65,24 @@ var heightSyncCmd = &cobra.Command{
 			homePath = utils.GetHomePathFromBinary(binaryPath)
 		}
 
+		defaultEngine := engines.EngineFactory(engine, homePath, rpcServerPort)
+
+		if source == "" {
+			s, err := defaultEngine.GetChainId()
+			if err != nil {
+				logger.Error().Msgf("Failed to load chain-id from engine: %s", err.Error())
+				os.Exit(1)
+			}
+			source = s
+			logger.Info().Msgf("Loaded source \"%s\" from genesis file", source)
+		}
+
 		bId, sId, err := sources.GetPoolIds(chainId, source, blockPoolId, snapshotPoolId, registryUrl, true, true)
 		if err != nil {
 			logger.Error().Msg(fmt.Sprintf("failed to load pool-ids: %s", err))
 			os.Exit(1)
 		}
 
-		defaultEngine := engines.EngineFactory(engine, homePath, rpcServerPort)
 		if reset {
 			if err := defaultEngine.ResetAll(true); err != nil {
 				logger.Error().Msg(fmt.Sprintf("failed to reset tendermint application: %s", err))

--- a/cmd/ksync/commands/serveblocks.go
+++ b/cmd/ksync/commands/serveblocks.go
@@ -64,13 +64,24 @@ var serveBlocksCmd = &cobra.Command{
 			homePath = utils.GetHomePathFromBinary(binaryPath)
 		}
 
+		defaultEngine := engines.EngineFactory(engine, homePath, rpcServerPort)
+
+		if source == "" {
+			s, err := defaultEngine.GetChainId()
+			if err != nil {
+				logger.Error().Msgf("Failed to load chain-id from engine: %s", err.Error())
+				os.Exit(1)
+			}
+			source = s
+			logger.Info().Msgf("Loaded source \"%s\" from genesis file", source)
+		}
+
 		backupCfg, err := backup.GetBackupConfig(homePath, backupInterval, backupKeepRecent, backupCompression, backupDest)
 		if err != nil {
 			logger.Error().Str("err", err.Error()).Msg("could not get backup config")
 			return
 		}
 
-		defaultEngine := engines.EngineFactory(engine, homePath, rpcServerPort)
 		if reset {
 			if err := defaultEngine.ResetAll(true); err != nil {
 				logger.Error().Msg(fmt.Sprintf("failed to reset tendermint application: %s", err))

--- a/cmd/ksync/commands/servesnapshots.go
+++ b/cmd/ksync/commands/servesnapshots.go
@@ -66,13 +66,24 @@ var servesnapshotsCmd = &cobra.Command{
 			homePath = utils.GetHomePathFromBinary(binaryPath)
 		}
 
+		defaultEngine := engines.EngineFactory(engine, homePath, rpcServerPort)
+
+		if source == "" {
+			s, err := defaultEngine.GetChainId()
+			if err != nil {
+				logger.Error().Msgf("Failed to load chain-id from engine: %s", err.Error())
+				os.Exit(1)
+			}
+			source = s
+			logger.Info().Msgf("Loaded source \"%s\" from genesis file", source)
+		}
+
 		bId, sId, err := sources.GetPoolIds(chainId, source, blockPoolId, snapshotPoolId, registryUrl, true, true)
 		if err != nil {
 			logger.Error().Msg(fmt.Sprintf("failed to load pool-ids: %s", err))
 			os.Exit(1)
 		}
 
-		defaultEngine := engines.EngineFactory(engine, homePath, rpcServerPort)
 		if reset {
 			if err := defaultEngine.ResetAll(true); err != nil {
 				logger.Error().Msg(fmt.Sprintf("failed to reset tendermint application: %s", err))

--- a/cmd/ksync/commands/statesync.go
+++ b/cmd/ksync/commands/statesync.go
@@ -62,13 +62,24 @@ var stateSyncCmd = &cobra.Command{
 			homePath = utils.GetHomePathFromBinary(binaryPath)
 		}
 
+		defaultEngine := engines.EngineFactory(engine, homePath, rpcServerPort)
+
+		if source == "" {
+			s, err := defaultEngine.GetChainId()
+			if err != nil {
+				logger.Error().Msgf("Failed to load chain-id from engine: %s", err.Error())
+				os.Exit(1)
+			}
+			source = s
+			logger.Info().Msgf("Loaded source \"%s\" from genesis file", source)
+		}
+
 		_, sId, err := sources.GetPoolIds(chainId, source, "", snapshotPoolId, registryUrl, false, true)
 		if err != nil {
 			logger.Error().Msg(fmt.Sprintf("failed to load pool-ids: %s", err))
 			os.Exit(1)
 		}
 
-		defaultEngine := engines.EngineFactory(engine, homePath, rpcServerPort)
 		if reset {
 			if err := defaultEngine.ResetAll(true); err != nil {
 				logger.Error().Msg(fmt.Sprintf("failed to reset tendermint application: %s", err))

--- a/engines/celestia-core-v34/celestiacore.go
+++ b/engines/celestia-core-v34/celestiacore.go
@@ -178,10 +178,13 @@ func (engine *Engine) StopProxyApp() error {
 }
 
 func (engine *Engine) GetChainId() (string, error) {
-	defaultDocProvider := nm.DefaultGenesisDocProviderFunc(engine.config)
-	_, genDoc, err := nm.LoadStateFromDBOrGenesisDocProvider(engine.stateDB, defaultDocProvider)
+	if err := engine.LoadConfig(); err != nil {
+		return "", fmt.Errorf("failed to load config: %w", err)
+	}
+
+	genDoc, err := nm.DefaultGenesisDocProviderFunc(engine.config)()
 	if err != nil {
-		return "", fmt.Errorf("failed to load state and genDoc: %w", err)
+		return "", fmt.Errorf("failed to load genDoc: %w", err)
 	}
 
 	return genDoc.ChainID, nil

--- a/engines/cometbft-v37/cometbft.go
+++ b/engines/cometbft-v37/cometbft.go
@@ -177,10 +177,13 @@ func (engine *Engine) StopProxyApp() error {
 }
 
 func (engine *Engine) GetChainId() (string, error) {
-	defaultDocProvider := nm.DefaultGenesisDocProviderFunc(engine.config)
-	_, genDoc, err := nm.LoadStateFromDBOrGenesisDocProvider(engine.stateDB, defaultDocProvider)
+	if err := engine.LoadConfig(); err != nil {
+		return "", fmt.Errorf("failed to load config: %w", err)
+	}
+
+	genDoc, err := nm.DefaultGenesisDocProviderFunc(engine.config)()
 	if err != nil {
-		return "", fmt.Errorf("failed to load state and genDoc: %w", err)
+		return "", fmt.Errorf("failed to load genDoc: %w", err)
 	}
 
 	return genDoc.ChainID, nil

--- a/engines/cometbft-v38/cometbft.go
+++ b/engines/cometbft-v38/cometbft.go
@@ -179,10 +179,13 @@ func (engine *Engine) StopProxyApp() error {
 }
 
 func (engine *Engine) GetChainId() (string, error) {
-	defaultDocProvider := nm.DefaultGenesisDocProviderFunc(engine.config)
-	_, genDoc, err := nm.LoadStateFromDBOrGenesisDocProvider(engine.stateDB, defaultDocProvider)
+	if err := engine.LoadConfig(); err != nil {
+		return "", fmt.Errorf("failed to load config: %w", err)
+	}
+
+	genDoc, err := nm.DefaultGenesisDocProviderFunc(engine.config)()
 	if err != nil {
-		return "", fmt.Errorf("failed to load state and genDoc: %w", err)
+		return "", fmt.Errorf("failed to load genDoc: %w", err)
 	}
 
 	return genDoc.ChainID, nil

--- a/engines/tendermint-v34/tendermint.go
+++ b/engines/tendermint-v34/tendermint.go
@@ -178,7 +178,16 @@ func (engine *Engine) StopProxyApp() error {
 }
 
 func (engine *Engine) GetChainId() (string, error) {
-	return engine.genDoc.ChainID, nil
+	if err := engine.LoadConfig(); err != nil {
+		return "", fmt.Errorf("failed to load config: %w", err)
+	}
+
+	genDoc, err := nm.DefaultGenesisDocProviderFunc(engine.config)()
+	if err != nil {
+		return "", fmt.Errorf("failed to load genDoc: %w", err)
+	}
+
+	return genDoc.ChainID, nil
 }
 
 func (engine *Engine) GetContinuationHeight() (int64, error) {


### PR DESCRIPTION
The `--source` flag is a convinience flag so the block pool id and the snapshot pool id don't have to be specified manually. Since the source flag is either the name or the chain-id of the source we can automatically infer it from the genesis file which can be obtained if the home is known which is always the case. From now on the --source flag will not be needed anymore, however it still can be overriden by specifying `--source=<your_source>`