### PR TITLE
chore: autodetect engine

### DIFF
--- a/cmd/ksync/commands/blocksync.go
+++ b/cmd/ksync/commands/blocksync.go
@@ -71,6 +71,11 @@ var blockSyncCmd = &cobra.Command{
 			homePath = utils.GetHomePathFromBinary(binaryPath)
 		}
 
+		if engine == "" && binaryPath != "" {
+			engine = utils.GetEnginePathFromBinary(binaryPath)
+			logger.Info().Msgf("Loaded engine \"%s\" from binary path", engine)
+		}
+
 		bId, _, err := sources.GetPoolIds(chainId, source, blockPoolId, "", registryUrl, true, false)
 		if err != nil {
 			logger.Error().Msg(fmt.Sprintf("failed to load pool-ids: %s", err))

--- a/cmd/ksync/commands/heightsync.go
+++ b/cmd/ksync/commands/heightsync.go
@@ -65,6 +65,11 @@ var heightSyncCmd = &cobra.Command{
 			homePath = utils.GetHomePathFromBinary(binaryPath)
 		}
 
+		if engine == "" && binaryPath != "" {
+			engine = utils.GetEnginePathFromBinary(binaryPath)
+			logger.Info().Msgf("Loaded engine \"%s\" from binary path", engine)
+		}
+
 		bId, sId, err := sources.GetPoolIds(chainId, source, blockPoolId, snapshotPoolId, registryUrl, true, true)
 		if err != nil {
 			logger.Error().Msg(fmt.Sprintf("failed to load pool-ids: %s", err))

--- a/cmd/ksync/commands/serveblocks.go
+++ b/cmd/ksync/commands/serveblocks.go
@@ -64,6 +64,11 @@ var serveBlocksCmd = &cobra.Command{
 			homePath = utils.GetHomePathFromBinary(binaryPath)
 		}
 
+		if engine == "" && binaryPath != "" {
+			engine = utils.GetEnginePathFromBinary(binaryPath)
+			logger.Info().Msgf("Loaded engine \"%s\" from binary path", engine)
+		}
+
 		backupCfg, err := backup.GetBackupConfig(homePath, backupInterval, backupKeepRecent, backupCompression, backupDest)
 		if err != nil {
 			logger.Error().Str("err", err.Error()).Msg("could not get backup config")

--- a/cmd/ksync/commands/servesnapshots.go
+++ b/cmd/ksync/commands/servesnapshots.go
@@ -66,6 +66,11 @@ var servesnapshotsCmd = &cobra.Command{
 			homePath = utils.GetHomePathFromBinary(binaryPath)
 		}
 
+		if engine == "" && binaryPath != "" {
+			engine = utils.GetEnginePathFromBinary(binaryPath)
+			logger.Info().Msgf("Loaded engine \"%s\" from binary path", engine)
+		}
+
 		bId, sId, err := sources.GetPoolIds(chainId, source, blockPoolId, snapshotPoolId, registryUrl, true, true)
 		if err != nil {
 			logger.Error().Msg(fmt.Sprintf("failed to load pool-ids: %s", err))

--- a/cmd/ksync/commands/statesync.go
+++ b/cmd/ksync/commands/statesync.go
@@ -62,6 +62,11 @@ var stateSyncCmd = &cobra.Command{
 			homePath = utils.GetHomePathFromBinary(binaryPath)
 		}
 
+		if engine == "" && binaryPath != "" {
+			engine = utils.GetEnginePathFromBinary(binaryPath)
+			logger.Info().Msgf("Loaded engine \"%s\" from binary path", engine)
+		}
+
 		_, sId, err := sources.GetPoolIds(chainId, source, "", snapshotPoolId, registryUrl, false, true)
 		if err != nil {
 			logger.Error().Msg(fmt.Sprintf("failed to load pool-ids: %s", err))

--- a/utils/binaries.go
+++ b/utils/binaries.go
@@ -48,6 +48,51 @@ func GetHomePathFromBinary(binaryPath string) string {
 	return ""
 }
 
+func GetEnginePathFromBinary(binaryPath string) string {
+	cmdPath, err := exec.LookPath(binaryPath)
+	if err != nil {
+		logger.Error().Msg(fmt.Sprintf("failed to lookup binary path: %s", err.Error()))
+		os.Exit(1)
+	}
+
+	startArgs := make([]string, 0)
+
+	// if we run with cosmovisor we start with the cosmovisor run command
+	if strings.HasSuffix(binaryPath, "cosmovisor") {
+		startArgs = append(startArgs, "run")
+	}
+
+	startArgs = append(startArgs, "version", "--long")
+
+	out, err := exec.Command(cmdPath, startArgs...).CombinedOutput()
+	if err != nil {
+		logger.Error().Msg("failed to get output of binary")
+		os.Exit(1)
+	}
+
+	for _, engine := range []string{"github.com/tendermint/tendermint@v", "github.com/cometbft/cometbft@v"} {
+		for _, line := range strings.Split(string(out), "\n") {
+			if strings.Contains(line, fmt.Sprintf("- %s", engine)) {
+				dependency := strings.Split(strings.ReplaceAll(strings.Split(line, " => ")[len(strings.Split(line, " => "))-1], "- ", ""), "@v")
+
+				if strings.Contains(dependency[1], "0.34.") && strings.Contains(dependency[0], "celestia-core") {
+					return EngineCelestiaCoreV34
+				} else if strings.Contains(dependency[1], "0.34.") {
+					return EngineTendermintV34
+				} else if strings.Contains(dependency[1], "0.37.") {
+					return EngineCometBFTV37
+				} else if strings.Contains(dependency[1], "0.38.") {
+					return EngineCometBFTV38
+				}
+			}
+		}
+	}
+
+	logger.Error().Msg("did not found engine in entire binary output")
+	os.Exit(1)
+	return ""
+}
+
 func StartBinaryProcessForDB(engine types.Engine, binaryPath string, debug bool, args []string) (processId int, err error) {
 	if binaryPath == "" {
 		return


### PR DESCRIPTION
With this PR the engine can be automatically inferred by reading the correct engine from the binary version --long command which yields all dependencies as output. From now on specifying the engine with the --engine flag is obsolete and is automatically detected if the binary is specified