### PR TITLE
fix: timeiotams bug

### DIFF
--- a/engines/celestia-core-v34/celestiacore.go
+++ b/engines/celestia-core-v34/celestiacore.go
@@ -644,6 +644,14 @@ func (engine *Engine) BootstrapState(rawState, rawSeenCommit, rawBlock []byte) e
 		return fmt.Errorf("failed to unmarshal block: %w", err)
 	}
 
+	// if TimeIotaMs is zero we set it to 1 else the app would panic.
+	// in rare circumstances this can be zero if the snapshot got
+	// created with the engine cometbft-v0.37 or cometbft-v0.38 but the
+	// height is still for tendermint-v0.34
+	if state.ConsensusParams.Block.TimeIotaMs == 0 {
+		state.ConsensusParams.Block.TimeIotaMs = 1
+	}
+
 	err := engine.stateStore.Bootstrap(*state)
 	if err != nil {
 		return fmt.Errorf("failed to bootstrap state: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/KYVENetwork/ksync
 go 1.22.4
 
 require (
-	github.com/KYVENetwork/celestia-core v1.47.0-tm-v0.34.29
+	github.com/KYVENetwork/celestia-core v1.50.0-tm-v0.34.29
 	github.com/KYVENetwork/cometbft/v37 v37.0.3
 	github.com/KYVENetwork/cometbft/v38 v38.0.4
 	github.com/cometbft/cometbft-db v0.9.5
@@ -29,7 +29,7 @@ require (
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
-	github.com/cosmos/gogoproto v1.4.11 // indirect
+	github.com/cosmos/gogoproto v1.7.0 // indirect
 	github.com/creachadair/taskgroup v0.13.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/ChainSafe/go-schnorrkel v1.0.0 h1:3aDA67lAykLaG1y3AOjs88dMxC88PgUuHRrLeDnvGIM=
 github.com/ChainSafe/go-schnorrkel v1.0.0/go.mod h1:dpzHYVxLZcp8pjlV+O+UR8K0Hp/z7vcchBSbMBEhCw4=
-github.com/KYVENetwork/celestia-core v1.47.0-tm-v0.34.29 h1:MaXU8B5EcAdf9FcryMaUsZtcizabH/N1uRcp/LR/Jgo=
-github.com/KYVENetwork/celestia-core v1.47.0-tm-v0.34.29/go.mod h1:F24hB7hFzH/7oXDPwC0csYnzoyprrGiHkMh/PHtIRY4=
+github.com/KYVENetwork/celestia-core v1.50.0-tm-v0.34.29 h1:yeR+6Wm85UAfxc5s6OYersm2IvO21NTuFAmS7MG39Xk=
+github.com/KYVENetwork/celestia-core v1.50.0-tm-v0.34.29/go.mod h1:IifwmY1S2n7YckIgU4d2CLKq7TQ5Oo7dhT00fYX88OM=
 github.com/KYVENetwork/cometbft v0.34.35 h1:kSwb+Is995tvI5xaYX6RQ9GRVrfMMXzpUHS+Yei+MxQ=
 github.com/KYVENetwork/cometbft v0.34.35/go.mod h1:SA1at6NTspQqvJ3Ud9TV9ixb0xgzoWNHGZVOU4HO+mM=
 github.com/KYVENetwork/cometbft/v37 v37.0.3 h1:kimHuadNTh3qDHfuB5eYyixoEGLpmnmYDc4dVsPG/jA=
@@ -61,8 +61,8 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d h1:49RLWk1j44Xu4fjHb6JFYmeUnDORVwHNkDxaQ0ctCVU=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
-github.com/cosmos/gogoproto v1.4.11 h1:LZcMHrx4FjUgrqQSWeaGC1v/TeuVFqSLa43CC6aWR2g=
-github.com/cosmos/gogoproto v1.4.11/go.mod h1:/g39Mh8m17X8Q/GDEs5zYTSNaNnInBSohtaxzQnYq1Y=
+github.com/cosmos/gogoproto v1.7.0 h1:79USr0oyXAbxg3rspGh/m4SWNyoz/GLaAh0QlCe2fro=
+github.com/cosmos/gogoproto v1.7.0/go.mod h1:yWChEv5IUEYURQasfyBW5ffkMHR/90hiHgbNgrtp4j0=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creachadair/taskgroup v0.13.0 h1:VKaW1fi1/Erkkrvx4NvaddzHCGA+hh5QPc5Veiq+joI=


### PR DESCRIPTION
This PR fixes a bug which can be reproduced with:

```
ksync state-sync --opt-out -b ./celestia-appd-v2.2.0 -d -l -r -t 2400000
./celestia-appd-v2.2.0 start --p2p.seeds="ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:11656"
```

which throws the following panic:

```
panic: Failed to process committed block (2400001:2EBC42F0C98379203D57C118D13D2CCD9F9ADD4849A176ECCDE19808073C2D53): commit failed for application: error updating consensus params: block.TimeIotaMs must be greater than 0. Got 0

goroutine 147 [running]:
github.com/tendermint/tendermint/blockchain/v0.(*BlockchainReactor).poolRoutine(0x14000583c00, 0x0)
	/root/go/pkg/mod/github.com/celestiaorg/celestia-core@v1.42.0-tm-v0.34.35/blockchain/v0/reactor.go:418 +0xe44
created by github.com/tendermint/tendermint/blockchain/v0.(*BlockchainReactor).OnStart in goroutine 67
	/root/go/pkg/mod/github.com/celestiaorg/celestia-core@v1.42.0-tm-v0.34.35/blockchain/v0/reactor.go:112 +0x78
```

With this PR this error does not occur anymore and instead syncs the blocks normally