### PR TITLE
chore: mark unused flags as deprecated

### DIFF
--- a/cmd/ksync/commands/blocksync.go
+++ b/cmd/ksync/commands/blocksync.go
@@ -37,6 +37,16 @@ func init() {
 	blockSyncCmd.Flags().BoolVarP(&flags.AppLogs, "app-logs", "l", false, "show logs from cosmos app")
 	blockSyncCmd.Flags().BoolVarP(&flags.Y, "yes", "y", false, "automatically answer yes for all questions")
 
+	// deprecated flags
+	blockSyncCmd.Flags().StringVarP(&flags.Engine, "engine", "e", "", "")
+	_ = blockSyncCmd.Flags().MarkDeprecated("engine", "engine is detected automatically")
+
+	blockSyncCmd.Flags().StringVarP(&flags.Source, "source", "s", "", "")
+	_ = blockSyncCmd.Flags().MarkDeprecated("source", "source is detected automatically")
+
+	blockSyncCmd.Flags().StringVar(&flags.RegistryUrl, "registry-url", "", "")
+	_ = blockSyncCmd.Flags().MarkDeprecated("registry-url", "registry url is fixed")
+
 	RootCmd.AddCommand(blockSyncCmd)
 }
 

--- a/cmd/ksync/commands/heightsync.go
+++ b/cmd/ksync/commands/heightsync.go
@@ -35,6 +35,16 @@ func init() {
 	heightSyncCmd.Flags().BoolVarP(&flags.AppLogs, "app-logs", "l", false, "show logs from cosmos app")
 	heightSyncCmd.Flags().BoolVarP(&flags.Y, "assumeyes", "y", false, "automatically answer yes for all questions")
 
+	// deprecated flags
+	heightSyncCmd.Flags().StringVarP(&flags.Engine, "engine", "e", "", "")
+	_ = heightSyncCmd.Flags().MarkDeprecated("engine", "engine is detected automatically")
+
+	heightSyncCmd.Flags().StringVarP(&flags.Source, "source", "s", "", "")
+	_ = heightSyncCmd.Flags().MarkDeprecated("source", "source is detected automatically")
+
+	heightSyncCmd.Flags().StringVar(&flags.RegistryUrl, "registry-url", "", "")
+	_ = heightSyncCmd.Flags().MarkDeprecated("registry-url", "registry url is fixed")
+
 	RootCmd.AddCommand(heightSyncCmd)
 }
 

--- a/cmd/ksync/commands/serveblocks.go
+++ b/cmd/ksync/commands/serveblocks.go
@@ -37,6 +37,16 @@ func init() {
 	serveBlocksCmd.Flags().BoolVarP(&flags.AppLogs, "app-logs", "l", false, "show logs from cosmos app")
 	serveBlocksCmd.Flags().BoolVarP(&flags.Y, "yes", "y", false, "automatically answer yes for all questions")
 
+	// deprecated flags
+	serveBlocksCmd.Flags().StringVarP(&flags.Engine, "engine", "e", "", "")
+	_ = serveBlocksCmd.Flags().MarkDeprecated("engine", "engine is detected automatically")
+
+	serveBlocksCmd.Flags().StringVarP(&flags.Source, "source", "s", "", "")
+	_ = serveBlocksCmd.Flags().MarkDeprecated("source", "source is detected automatically")
+
+	serveBlocksCmd.Flags().StringVar(&flags.RegistryUrl, "registry-url", "", "")
+	_ = serveBlocksCmd.Flags().MarkDeprecated("registry-url", "registry url is fixed")
+
 	RootCmd.AddCommand(serveBlocksCmd)
 }
 

--- a/cmd/ksync/commands/servesnapshots.go
+++ b/cmd/ksync/commands/servesnapshots.go
@@ -44,6 +44,16 @@ func init() {
 	servesnapshotsCmd.Flags().BoolVarP(&flags.Debug, "debug", "d", false, "run KSYNC in debug mode")
 	servesnapshotsCmd.Flags().BoolVarP(&flags.AppLogs, "app-logs", "l", false, "show logs from cosmos app")
 
+	// deprecated flags
+	servesnapshotsCmd.Flags().StringVarP(&flags.Engine, "engine", "e", "", "")
+	_ = servesnapshotsCmd.Flags().MarkDeprecated("engine", "engine is detected automatically")
+
+	servesnapshotsCmd.Flags().StringVarP(&flags.Source, "source", "s", "", "")
+	_ = servesnapshotsCmd.Flags().MarkDeprecated("source", "source is detected automatically")
+
+	servesnapshotsCmd.Flags().StringVar(&flags.RegistryUrl, "registry-url", "", "")
+	_ = servesnapshotsCmd.Flags().MarkDeprecated("registry-url", "registry url is fixed")
+
 	RootCmd.AddCommand(servesnapshotsCmd)
 }
 

--- a/cmd/ksync/commands/statesync.go
+++ b/cmd/ksync/commands/statesync.go
@@ -34,6 +34,16 @@ func init() {
 	stateSyncCmd.Flags().BoolVarP(&flags.AppLogs, "app-logs", "l", false, "show logs from cosmos app")
 	stateSyncCmd.Flags().BoolVarP(&flags.Y, "yes", "y", false, "automatically answer yes for all questions")
 
+	// deprecated flags
+	stateSyncCmd.Flags().StringVarP(&flags.Engine, "engine", "e", "", "")
+	_ = stateSyncCmd.Flags().MarkDeprecated("engine", "engine is detected automatically")
+
+	stateSyncCmd.Flags().StringVarP(&flags.Source, "source", "s", "", "")
+	_ = stateSyncCmd.Flags().MarkDeprecated("source", "source is detected automatically")
+
+	stateSyncCmd.Flags().StringVar(&flags.RegistryUrl, "registry-url", "", "")
+	_ = stateSyncCmd.Flags().MarkDeprecated("registry-url", "registry url is fixed")
+
 	RootCmd.AddCommand(stateSyncCmd)
 }
 

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -28,4 +28,10 @@ var (
 	OptOut                  bool
 	Debug                   bool
 	Y                       bool
+	// Engine is deprecated
+	Engine string
+	// Source is deprecated
+	Source string
+	// RegistryUrl is deprecated
+	RegistryUrl string
 )


### PR DESCRIPTION
Mark unused flags as deprecated instead of removing them to ensure backwards compatibility. Else all service files which mostly still contain the `--engine` flag would fail