### PR TITLE
chore: start serve-snapshots from second latest snapshot

### DIFF
--- a/app/collector/snapshots.go
+++ b/app/collector/snapshots.go
@@ -83,10 +83,15 @@ func (collector *KyveSnapshotCollector) GetInterval() int64 {
 	return collector.interval
 }
 
-func (collector *KyveSnapshotCollector) GetSnapshotHeight(targetHeight int64) int64 {
+func (collector *KyveSnapshotCollector) GetSnapshotHeight(targetHeight int64, isServeSnapshot bool) int64 {
 	// if no target height was given the snapshot height is the latest available,
 	// also if the target height is greater than the latest available height
 	if targetHeight == 0 || targetHeight > collector.latestAvailableHeight {
+		// if we run the serve-snapshot command we actually do not want to sync to the latest available height
+		// or else the node operator has to wait until the next snapshot is created in order to join the pool.
+		if isServeSnapshot && collector.latestAvailableHeight > collector.interval {
+			return collector.latestAvailableHeight - collector.interval
+		}
 		return collector.latestAvailableHeight
 	}
 

--- a/sync/heightsync/heightsync.go
+++ b/sync/heightsync/heightsync.go
@@ -46,7 +46,7 @@ func Start() error {
 		return fmt.Errorf("failed to init kyve block collector: %w", err)
 	}
 
-	snapshotHeight := snapshotCollector.GetSnapshotHeight(flags.TargetHeight)
+	snapshotHeight := snapshotCollector.GetSnapshotHeight(flags.TargetHeight, false)
 	metrics.SetSnapshotHeight(snapshotHeight)
 
 	canApplySnapshot := snapshotHeight > 0 && app.IsReset()

--- a/sync/servesnapshots/servesnapshots.go
+++ b/sync/servesnapshots/servesnapshots.go
@@ -53,7 +53,9 @@ func Start() error {
 		return fmt.Errorf("failed to init kyve block collector: %w", err)
 	}
 
-	snapshotHeight := snapshotCollector.GetSnapshotHeight(flags.StartHeight)
+	snapshotHeight := snapshotCollector.GetSnapshotHeight(flags.StartHeight, true)
+	if snapshotHeight < flags.StartHeight {
+	}
 	metrics.SetSnapshotHeight(snapshotHeight)
 
 	canApplySnapshot := snapshotHeight > 0 && app.IsReset()

--- a/sync/statesync/statesync.go
+++ b/sync/statesync/statesync.go
@@ -39,7 +39,7 @@ func Start() error {
 		return fmt.Errorf("failed to init kyve snapshot collector: %w", err)
 	}
 
-	snapshotHeight := snapshotCollector.GetSnapshotHeight(flags.TargetHeight)
+	snapshotHeight := snapshotCollector.GetSnapshotHeight(flags.TargetHeight, false)
 	metrics.SetSnapshotHeight(snapshotHeight)
 
 	if snapshotHeight == 0 {

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -41,7 +41,7 @@ type SnapshotCollector interface {
 
 	// GetSnapshotHeight gets the exact height of the nearest snapshot before the target
 	// height
-	GetSnapshotHeight(targetHeight int64) int64
+	GetSnapshotHeight(targetHeight int64, isServeSnapshot bool) int64
 
 	// GetSnapshotFromBundleId gets the snapshot from the given bundle
 	GetSnapshotFromBundleId(bundleId int64) (*SnapshotDataItem, error)


### PR DESCRIPTION
When joining a live state-sync pool KSYNC syncs to the latest available snapshot height. But because it syncs from that height KSYNC is unable to serve it so the protocol node has to wait for the next snapshot which could take hours. This PR addresses this by syncing to the second latest snapshot height if starting with serve-snapshots.